### PR TITLE
Use JSON Patch for modified diff format

### DIFF
--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -2,6 +2,7 @@ const { Repo } = require('hologit/lib')
 const handlebars = require('handlebars')
 const csvParser = require('csv-parser')
 const TOML = require('@iarna/toml')
+const jsonpatch = require('fast-json-patch')
 
 module.exports = class GitSheets {
   static async create(gitDir = null) {
@@ -111,13 +112,12 @@ module.exports = class GitSheets {
             value: await this.parseBlob(srcChildren[diff.file])
           }
         case 'M':
+          const src = await this.parseBlob(srcChildren[diff.file])
+          const dst = await this.parseBlob(dstChildren[diff.file])
           return {
             _id: diff.file,
             status: 'modified',
-            value: {
-              src: await this.parseBlob(srcChildren[diff.file]),
-              dst: await this.parseBlob(dstChildren[diff.file])
-            }
+            value: jsonpatch.compare(src, dst)
           }
       }
     })

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1778,8 +1778,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
       "version": "3.0.4",
@@ -1847,6 +1846,14 @@
             "is-number": "^7.0.0"
           }
         }
+      }
+    },
+    "fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1"
       }
     },
     "fast-json-stable-stringify": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@iarna/toml": "^2.2.3",
     "csv-parser": "^2.3.0",
+    "fast-json-patch": "^2.2.1",
     "handlebars": "^4.1.2",
     "hologit": "^0.18.1",
     "http-assert": "^1.4.1",

--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -194,7 +194,12 @@ describe('server', () => {
       expect(modifiedDiff).toBeTruthy()
       expect(modifiedDiff.value.length).toBe(1)
 
-      const expectedPatch = { op: 'replace', path: '/last_name', value: 'Footsford' }
+      const expectedPatch = {
+        op: 'replace',
+        path: '/last_name',
+        from: 'Hansford',
+        value: 'Footsford'
+      }
       expect(modifiedDiff.value[0]).toMatchObject(expectedPatch)
     })
 


### PR DESCRIPTION
The "diff" (compare) endpoint returns an array of rows that have changed. Added and removed rows are easy: just provide the value of the old or new row. A modified row could either provide the value of both the old and new version of the row (and expect the client to compute the changes in order to display them), or provide the diff directly.

My first thought was to use a simple contract like `{first_name: {_old: 'abc', _new: 'def'}}`, but on looking for prior art it appears there's a related spec: [JSON Patch](https://tools.ietf.org/html/rfc6902) (RFC 6902). And [this library](https://www.npmjs.com/package/fast-json-patch) looks pretty handy.

The diff format ends up looking like this:

```js
[
  {op: "replace", path: "/user/lastName", value: "Collins", from: "Colens"},
  {op: "remove", path: "/user/ipAddress"}
]
```

Thoughts on this format? Ideas on alternatives?