### PR TITLE
Store path template in config file

### DIFF
--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -54,11 +54,14 @@ module.exports = class GitSheets {
     return tree.write()
   }
 
-  async makeTreeFromCsv ({ readStream, pathTemplate, ref }) {
+  async makeTreeFromCsv ({ readStream, pathTemplate, ref = null }) {
     const renderPath = handlebars.compile(pathTemplate)
-    const tree = (ref)
-      ? await this.repo.createTreeFromRef(ref)
-      : this.repo.createTree()
+    const tree = this.repo.createTree()
+
+    if (ref) {
+      const srcTree = await this.repo.createTreeFromRef(ref)
+      await tree.merge(srcTree, { files: ['.gitsheets/*'] })
+    }
 
     return new Promise ((resolve, reject) => {
       const pendingWrites = []

--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -28,6 +28,32 @@ module.exports = class GitSheets {
     }
   }
 
+  async getConfig (ref) {
+    const tree = await this.repo.createTreeFromRef(ref)
+    const child = await tree.getChild('.gitsheets/config')
+    return this.parseBlob(child)
+  }
+
+  async saveConfig (config, ref = null) {
+    const treeHash = await this.makeConfigTree(config, ref)
+    await this.saveTreeToExistingBranch({
+      treeHash,
+      branch: ref,
+      msg: 'save config'
+    })
+  }
+
+  async makeConfigTree (config, ref = null) {
+    const tomlConfig = TOML.stringify(config)
+    const path = '.gitsheets/config'
+    const tree = (ref)
+      ? await this.repo.createTreeFromRef(ref)
+      : this.repo.createTree()
+
+    await tree.writeChild(path, tomlConfig)
+    return tree.write()
+  }
+
   async makeTreeFromCsv ({ readStream, pathTemplate, ref }) {
     const renderPath = handlebars.compile(pathTemplate)
     const tree = (ref)

--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -1,4 +1,4 @@
-const { Repo } = require('hologit/lib')
+const { Repo, BlobObject } = require('hologit/lib')
 const handlebars = require('handlebars')
 const csvParser = require('csv-parser')
 const TOML = require('@iarna/toml')
@@ -108,9 +108,11 @@ module.exports = class GitSheets {
     const rows = []
     for (let key in keyedChildren) {
       const child = keyedChildren[key]
-      const data = await this.parseBlob(child)
-      data._id = key
-      rows.push(data)
+      if (child instanceof BlobObject) {
+        const data = await this.parseBlob(child)
+        data._id = key
+        rows.push(data)
+      }
     }
     return rows
   }

--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -31,7 +31,7 @@ module.exports = class GitSheets {
   async getConfig (ref) {
     const tree = await this.repo.createTreeFromRef(ref)
     const child = await tree.getChild('.gitsheets/config')
-    return this.parseBlob(child)
+    return child && this.parseBlob(child)
   }
 
   async saveConfig (config, ref = null) {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -935,6 +935,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1070,6 +1075,17 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
+    "co-body": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.0.0.tgz",
+      "integrity": "sha512-9ZIcixguuuKIptnY8yemEOuhb71L/lLf+Rl5JfJEUiDNJk0e02MBt7BPxR2GEh5mw8dPthQYR4jPI/BnS1MQgw==",
+      "requires": {
+        "inflation": "^2.0.0",
+        "qs": "^6.5.2",
+        "raw-body": "^2.3.3",
+        "type-is": "^1.6.16"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1185,6 +1201,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2997,7 +3018,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -3023,6 +3043,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "inflation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
+      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8="
     },
     "inflight": {
       "version": "1.0.6",
@@ -4282,6 +4307,15 @@
         }
       }
     },
+    "koa-bodyparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.2.1.tgz",
+      "integrity": "sha512-UIjPAlMZfNYDDe+4zBaOAUKYqkwAGcIU6r2ARf1UOXPAlfennQys5IiShaVeNf7KkVBlf88f2LeLvBFvKylttw==",
+      "requires": {
+        "co-body": "^6.0.0",
+        "copy-to": "^2.0.1"
+      }
+    },
     "koa-compose": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
@@ -5220,8 +5254,18 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "raw-body": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.3",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
     },
     "react-is": {
       "version": "16.8.6",
@@ -5459,8 +5503,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -6249,6 +6292,11 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "hologit": "^0.18.1",
     "http-assert": "^1.4.1",
     "koa": "^2.7.0",
+    "koa-bodyparser": "^4.2.1",
     "koa-router": "^7.4.0",
     "to-readable-stream": "^2.1.0",
     "winston": "^2.4.3",

--- a/backend/server.js
+++ b/backend/server.js
@@ -88,7 +88,7 @@ async function createServer (gitSheets) {
     let pathTemplate
     try {
       const config = await gitSheets.getConfig(ref)
-      ctx.assert(config.path, 500, 'repository is missing path template config')
+      ctx.assert(config && config.path, 500, 'repository is missing path template config')
       pathTemplate = config.path
     } catch (err) {
       if (err.message.startsWith('invalid tree ref')) {
@@ -100,7 +100,7 @@ async function createServer (gitSheets) {
 
     let treeHash
     try {
-      treeHash = await gitSheets.makeTreeFromCsv({ readStream, pathTemplate })
+      treeHash = await gitSheets.makeTreeFromCsv({ readStream, pathTemplate, ref })
     } catch (err) {
       ctx.throw(422, err.message)
     }

--- a/backend/server.js
+++ b/backend/server.js
@@ -43,7 +43,7 @@ async function createServer (gitSheets) {
 
   router.put('/:ref', bodyParser(), async (ctx) => {
     const ref = ctx.params.ref
-    const path = ctx.request.body.path
+    const path = ctx.request.body.config && ctx.request.body.config.path
 
     ctx.assert(validRefPattern.test(ref), 400, 'invalid ref')
     ctx.assert(validPathTemplatePattern.test(path), 400, 'invalid path template')

--- a/backend/test/lib.spec.js
+++ b/backend/test/lib.spec.js
@@ -46,14 +46,12 @@ describe('lib', () => {
     await loadData(gitSheets, {
       data: sampleData,
       ref: 'master',
-      branch: 'master',
-      pathTemplate: '{{id}}'
+      branch: 'master'
     })
     await loadData(gitSheets, {
       data: sampleDataChanged,
       ref: 'master',
-      branch: 'proposal',
-      pathTemplate: '{{id}}'
+      branch: 'proposal'
     })
 
     const diffs = await gitSheets.getDiffs('master', 'proposal')

--- a/backend/test/lib.spec.js
+++ b/backend/test/lib.spec.js
@@ -10,7 +10,7 @@ const csv = stripIndent`
   2,Grace,Hopper
   3,Radia,Perlman
 `
-const expectedHash = 'fb070046498551bb49ce253ef13daddcb56949c1'
+const expectedHash = 'e9f02749cb91f919f25a3c55899ded04f63a7b1b'
 const TEST_GIT_DIR = './test/tmp/lib-test-repo/.git'
 const SAMPLE_DATA = './test/fixtures/sample_data.csv'
 const SAMPLE_DATA_CHANGED = './test/fixtures/sample_data_changed.csv'
@@ -38,7 +38,8 @@ describe('lib', () => {
   test('makeTreeFromCsv returns expected tree hash', async () => {
     const readStream = toReadableStream(csv)
     const pathTemplate = '{{id}}'
-    const hash = await gitSheets.makeTreeFromCsv({ readStream, pathTemplate })
+    const ref = 'master'
+    const hash = await gitSheets.makeTreeFromCsv({ readStream, pathTemplate, ref })
     expect(hash).toBe(expectedHash)
   })
 

--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -85,6 +85,15 @@ describe('server', () => {
       expect(response.body.length).toBe(getCsvRowCount(sampleData))
       expect(response.body[0]).toHaveProperty('_id')
     })
+
+    test('returns empty array if no data', async () => {
+      const response = await request(server.callback())
+        .get('/master/records')
+        .expect(200)
+
+      expect(Array.isArray(response.body)).toBe(true)
+      expect(response.body.length).toBe(0)
+    })
     
     test('requesting invalid ref throws error', async () => {
       await request(server.callback())

--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -59,7 +59,7 @@ describe('server', () => {
     test('updates config', async () => {
       await request(server.callback())
         .put('/master')
-        .send({ path: '{{id}}-updated'})
+        .send({ config: { path: '{{id}}-updated'} })
         .expect(204)
 
       const response = await request(server.callback())

--- a/backend/test/util/index.js
+++ b/backend/test/util/index.js
@@ -31,7 +31,7 @@ async function teardownRepo (gitSheets) {
 async function loadData (gitSheets, { data, ref, branch }) {
   const readStream = toReadableStream(data)
   const pathTemplate = '{{id}}'
-  const treeHash = await gitSheets.makeTreeFromCsv({ readStream, pathTemplate })
+  const treeHash = await gitSheets.makeTreeFromCsv({ readStream, pathTemplate, ref })
 
   if (ref === branch) {
     await gitSheets.saveTreeToExistingBranch({

--- a/backend/test/util/index.js
+++ b/backend/test/util/index.js
@@ -18,8 +18,9 @@ async function setupRepo (gitSheets) {
   await gitSheets.git.commit({
     'allow-empty': true,
     'allow-empty-message': true,
-    m: ''
+    m: 'initial commit'
   })
+  await gitSheets.saveConfig({ path: '{{id}}' }, 'master')
 }
 
 async function teardownRepo (gitSheets) {
@@ -27,8 +28,9 @@ async function teardownRepo (gitSheets) {
   await del([gitDir])
 }
 
-async function loadData (gitSheets, { data, ref, branch, pathTemplate }) {
+async function loadData (gitSheets, { data, ref, branch }) {
   const readStream = toReadableStream(data)
+  const pathTemplate = '{{id}}'
   const treeHash = await gitSheets.makeTreeFromCsv({ readStream, pathTemplate })
 
   if (ref === branch) {


### PR DESCRIPTION
I'd like to improve error filtering in `server.js`, but that need exists outside of this feature, so I'll treat it as a refactor branch separately.

As I mentioned in slack, GitSheets does not currently support multiple datasets in a repo, so this feature doesn't either. For that reason it uses `.gitsheets/config`. Should be a relatively easy fix to support multiple datasets (albeit breaking changes to the API) but is a distinct feature from this one.

~~EDIT: Don't merge yet; found an issue~~